### PR TITLE
Removing New Haven IO from the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,6 @@ Until something else rises to take its place, the archive of [**DenverTech.commu
   - **Rocky Mountain Angular** – [`Meetup`](https://www.meetup.com/RockyMountainAngular/)[ⓘ](## "Inactive since 2020-12-17.") – Statewide?
 </details>
 
-#### Connecticut
-
-- **NewHaven.io** – [`Website`](https://newhaven.io) • [`Discord`](https://discord.gg/yP7WxSXq5h) • [`GitHub`](https://github.com/newhavenio) • [`Google Groups`](https://groups.google.com/g/newhavenio)[ⓘ](## "Inactive since 2022-10-22.") • [`Meetup`](https://www.meetup.com/newhavenio/) • [`Twitter/X`](https://twitter.com/newhavenio)[ⓘ](## "Inactive since 2021-10-14.") – New Haven – NewHaven.io acts as the hub of the local tech community by helping its members learn, solve problems, and connect with the local tech scene.
-
 #### Florida
 
 - **Orlando Devs** – [`Website`](https://orlandodevs.com/) • [`Eventbrite`](https://www.eventbrite.com/o/orlando-devs-15266001174) • [`GitHub`](https://github.com/OrlandoDevs)[ⓘ](## "Inactive since 2022-10-25.") • [`Patreon`](https://www.patreon.com/odevs) • [`Slack`](https://orlandodevs.com/slack) • [Twitter/X](https://twitter.com/OrlandoDevs)[ⓘ](## "Inactive since 2023-01-27.") – Orlando – An open community and online chat for Software Developers with 1,000+ members. Who knew so many people were interested in writing code in Orlando, FL?


### PR DESCRIPTION
We're a local group and we've been getting too many remote members joining from this list. We'd like to remove ourselves.

I'm one of the admins over there, and you can find me on the group's about page (https://newhaven.io/about/).

I appreciate what y'all are doing, but we just don't need to be on this list anymore.